### PR TITLE
Ensure we're in station mode

### DIFF
--- a/examples/Button/Button.ino
+++ b/examples/Button/Button.ino
@@ -40,6 +40,7 @@ void setup() {
   Serial.println();
   Serial.println();
 
+  WiFi.mode(WIFI_STA);
   Serial.printf("Configuring wifi: %s\r\n", cfg.wifiSsid);
   WiFi.begin(cfg.wifiSsid, cfg.wifiPassword);
 


### PR DESCRIPTION
By default ESP8266s start in mixed mode where they provide both an access point, and connect to a WiFi. This should remove the AP broadcast